### PR TITLE
Add Reverse Image Location tool

### DIFF
--- a/src/data/extraAITools.ts
+++ b/src/data/extraAITools.ts
@@ -28,6 +28,20 @@ export const extraAITools: AITool[] = [
     modelType: 'Custom GPT',
     easeOfUse: 4.8,
     userExperience: 4.7
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440007",
+    name: 'Reverse Image Location',
+    description: 'AI photo geolocation tool that estimates where an image was taken and explains visible scene clues for OSINT and GeoGuessr-style practice.',
+    category: 'Research',
+    url: 'https://reverseimagelocation.com/',
+    image: 'https://reverseimagelocation.com/og-image.png',
+    pricing: 'Freemium',
+    rating: 4.6,
+    dailyUsers: 'N/A',
+    modelType: 'Visual geolocation',
+    easeOfUse: 4.6,
+    userExperience: 4.6
   }
   // Note: For brevity, I'm showing just the first two items. 
   // You should add unique UUIDs to ALL items in your actual file


### PR DESCRIPTION
## Related Issue
N/A

## Description
Adds Reverse Image Location to the local extra AI tools data as a Research tool. The entry links to the product homepage and describes the tool as AI-assisted photo geolocation with visible-clue reasoning for OSINT and GeoGuessr-style practice.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Other (specify): Tool listing data

## Screenshots / videos (if applicable)
N/A

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.

## Additional context:
This is a small data-only addition to src/data/extraAITools.ts. I verified the diff contains only the object addition plus the required comma on the previous array item.