### PR TITLE
Add GPTGeminiGrok.AI to the tools directory

### DIFF
--- a/src/data/extraAITools.ts
+++ b/src/data/extraAITools.ts
@@ -28,6 +28,20 @@ export const extraAITools: AITool[] = [
     modelType: 'Custom GPT',
     easeOfUse: 4.8,
     userExperience: 4.7
+  },
+  {
+    id: 'b6f3a91d-8c2e-4e73-a54b-0d9f1267c842',
+    name: 'GPTGeminiGrok.AI',
+    description: 'Browser workspace for multi-model AI chat, image generation, and file analysis',
+    category: 'Chatbots',
+    url: 'https://trygrokai.asia/',
+    image: 'https://trygrokai.asia/app/logo.png',
+    pricing: 'Freemium - 10 requests/day',
+    rating: 0,
+    dailyUsers: 'N/A',
+    modelType: 'Multi-model AI',
+    easeOfUse: 'N/A',
+    userExperience: 'N/A'
   }
   // Note: For brevity, I'm showing just the first two items. 
   // You should add unique UUIDs to ALL items in your actual file


### PR DESCRIPTION
## Summary

Adds GPTGeminiGrok.AI as one structured tool entry using its canonical URL and official logo.

## Data accuracy

The product requires an account and currently includes 10 free requests per day. Unknown audience and review metrics are recorded as N/A/0 rather than estimated. I am submitting this on behalf of the product operator.